### PR TITLE
Prevent reinstalling requirements if they haven't changed.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3
+COPY ./requirements.txt /app/
+RUN pip install -r /app/requirements.txt
 COPY . /app
 WORKDIR /app
-RUN pip install -r requirements.txt
 EXPOSE 8006
 CMD ["python", "json_head.py"]


### PR DESCRIPTION
Sorry, not sure if you care, but I read your article at https://simonwillison.net/2017/Oct/14/async-python-sanic-now/ and couldn't help myself.  On my fiber connection, this cuts Docker build times from 12 seconds to two when the requirements.txt hasn't changed.